### PR TITLE
프로필 페이지 CustomerSession에 따른 분기 에러 픽스

### DIFF
--- a/src/main/java/hana/teamfour/addminhana/controller/ProfileController.java
+++ b/src/main/java/hana/teamfour/addminhana/controller/ProfileController.java
@@ -46,6 +46,17 @@ public class ProfileController extends HttpServlet {
         CustomerSessionDTO customerSession = (CustomerSessionDTO) session.getAttribute("customerSession");
         try {
             CustomerSummaryDTO customerSummaryDTO = null;
+            if (action != null && action.equals("description")) {
+                customerSummaryDTO = customerService.getCustomerSummaryDTOById(customerSession.getC_id());
+                System.out.println("customerSummaryDTO = " + customerSummaryDTO);
+                customerSummaryDTO.setC_description(description);
+                boolean hasUpdated = customerService.updateCustomerDescription(customerSummaryDTO);
+                request.setAttribute("hasUpdatedDescription", hasUpdated);
+                request.setAttribute("customerSummaryDTO", customerSummaryDTO);
+                RequestDispatcher dispatcher = request.getRequestDispatcher(profilePage);
+                dispatcher.forward(request, response);
+                return;
+            }
             if (customerSession == null) {
                 customerSummaryDTO = customerService.getCustomerSummaryDTOByRRN(customerRRN);
                 if (customerSummaryDTO == null) {
@@ -64,12 +75,6 @@ public class ProfileController extends HttpServlet {
                 CustomerSessionDTO customerSessionDTO = customerSummaryDTO.getCustomerSessionDTO();
                 session.setAttribute("customerSession", customerSessionDTO);
                 request.setAttribute("customerSummaryDTO", customerSummaryDTO);
-                if (action != null && action.equals("description")) {
-                    customerSummaryDTO.setC_description(description);
-                    boolean hasUpdated = customerService.updateCustomerDescription(customerSummaryDTO);
-                    request.setAttribute("hasUpdatedDescription", hasUpdated);
-                    request.setAttribute("customerSummaryDTO", customerSummaryDTO);
-                }
                 RequestDispatcher dispatcher = request.getRequestDispatcher(profilePage);
                 dispatcher.forward(request, response);
                 return;

--- a/src/main/java/hana/teamfour/addminhana/controller/ProfileController.java
+++ b/src/main/java/hana/teamfour/addminhana/controller/ProfileController.java
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
-@WebServlet("/profile/*")
+@WebServlet("/customer/profile/*")
 public class ProfileController extends HttpServlet {
     ServletContext context = null;
     CustomerService customerService;
@@ -39,17 +39,26 @@ public class ProfileController extends HttpServlet {
     private void doHandle(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         HttpSession session = request.getSession(false);
         response.setContentType("text/html;charset=utf-8");
-        String nextPage = "/views/profile.jsp";
+        String profilePage = "/views/profile.jsp";
         String action = request.getParameter("action");
         String description = request.getParameter("descriptionText");
         String customerRRN = (String) request.getParameter("customerRRN");
         CustomerSessionDTO customerSession = (CustomerSessionDTO) session.getAttribute("customerSession");
         try {
             CustomerSummaryDTO customerSummaryDTO = null;
-            if (customerSession != null) {
-                customerSummaryDTO = customerService.getCustomerSummaryDTOById(customerSession.getC_id());
-            } else if (customerRRN != null) {
+            if (customerSession == null) {
                 customerSummaryDTO = customerService.getCustomerSummaryDTOByRRN(customerRRN);
+                if (customerSummaryDTO == null) {
+                    response.sendRedirect(request.getContextPath() + "/");
+                    return;
+                }
+            }
+            if (customerSession != null && customerRRN != null) {
+                customerSummaryDTO = customerService.getCustomerSummaryDTOByRRN(customerRRN);
+                if (customerSummaryDTO == null || (customerSummaryDTO.getC_id() != customerSession.getC_id())) {
+                    response.sendRedirect(request.getContextPath() + "/");
+                    return;
+                }
             }
             if (customerSummaryDTO != null) {
                 CustomerSessionDTO customerSessionDTO = customerSummaryDTO.getCustomerSessionDTO();
@@ -58,23 +67,23 @@ public class ProfileController extends HttpServlet {
                 if (action != null && action.equals("description")) {
                     customerSummaryDTO.setC_description(description);
                     boolean hasUpdated = customerService.updateCustomerDescription(customerSummaryDTO);
-                    // ! false 일 떄 토스트 뜨지 않게 테스트중 
-                    // TODO: profile 페이지에서 새로고침했을 때 Toast 뜨지 않도록 변경해야함
-                    // TODO: 새로고침했을 때 attribute를 삭제해줘야 하는 방법이 뭘까 ?
-                    // TODO: Toast를 한번 띄우고 attribute 삭제 콜을 해야할것 같기도 하고.. ?
                     request.setAttribute("hasUpdatedDescription", hasUpdated);
                     request.setAttribute("customerSummaryDTO", customerSummaryDTO);
                 }
-                RequestDispatcher dispatcher = request.getRequestDispatcher(nextPage);
+                RequestDispatcher dispatcher = request.getRequestDispatcher(profilePage);
                 dispatcher.forward(request, response);
                 return;
             }
-            nextPage = "/views/main.jsp";
-            RequestDispatcher dispatcher = request.getRequestDispatcher(nextPage);
-            dispatcher.forward(request, response);
+            forwardToMain(request, response);
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void forwardToMain(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String nextPage = "/views/main.jsp";
+        RequestDispatcher dispatcher = request.getRequestDispatcher(nextPage);
+        dispatcher.forward(request, response);
     }
 
     @Override

--- a/src/main/java/hana/teamfour/addminhana/filter/CustomerLoginFilter.java
+++ b/src/main/java/hana/teamfour/addminhana/filter/CustomerLoginFilter.java
@@ -15,12 +15,14 @@ public class CustomerLoginFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
         HttpSession session = request.getSession(false);
-        boolean loggedIn = session != null && session.getAttribute("customerSession") != null;
+        String loginURI = request.getContextPath() + "/customer/profile";
 
-        if (loggedIn) {
+        boolean loggedIn = session != null && session.getAttribute("customerSession") != null;
+        boolean loginRequest = request.getRequestURI().equals(loginURI);
+        if (!loggedIn || loginRequest) {
             chain.doFilter(request, response);
         } else {
-            response.sendRedirect(request.getContextPath() + "/main");
+            response.sendRedirect(request.getContextPath() + "/");
         }
     }
 }

--- a/src/main/webapp/views/main.jsp
+++ b/src/main/webapp/views/main.jsp
@@ -29,7 +29,7 @@
     </nav>
 
     <main class="d-flex flex-column justify-content-center gap-2 mx-4 w-100">
-      <form name="customerLoginForm" action="profile" method="post"
+      <form name="customerLoginForm" action="customer/profile" method="post"
             class="input-group input-group-lg flex-nowrap w-75">
           <span class="input-group-text" id="addon-wrapping">
             <i class="fas fa-magnifying-glass"></i>


### PR DESCRIPTION
### 코드 작성 이유
프로필 페이지에서 세션 유무에 따른 분기처리가 제대로 되지 않는 에러 발생
<br>

### 상세 사항
- 업데이트 액션의 경우 바로 리다이렉트하도록 변경
- 커스터머세션 필터의 로직 변경에 대응하여 프로필 페이지에서 세션에 따른 분기처리 변경
<br>

### 참고 사항

<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
