### PR TITLE
Fix: 커스터머 로그인 필터 에러 픽스

### DIFF
--- a/src/main/java/hana/teamfour/addminhana/filter/CustomerLoginFilter.java
+++ b/src/main/java/hana/teamfour/addminhana/filter/CustomerLoginFilter.java
@@ -19,7 +19,7 @@ public class CustomerLoginFilter implements Filter {
 
         boolean loggedIn = session != null && session.getAttribute("customerSession") != null;
         boolean loginRequest = request.getRequestURI().equals(loginURI);
-        if (!loggedIn || loginRequest) {
+        if (loggedIn || loginRequest) {
             chain.doFilter(request, response);
         } else {
             response.sendRedirect(request.getContextPath() + "/");


### PR DESCRIPTION
### 코드 작성 이유
낫연산자를 넣는 실수로 인해 에러 발생
<br>

### 상세 사항
- if문에 낫연산자 제거
<br>

### 참고 사항

<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
