### PR TITLE
Chore: 신규 손님 가입시 Asset 및 Specific 테이블에 트리거로 데이터 추가

### DIFF
--- a/src/main/resources/db/trigger/INSERT_ASSET_SPECIFIC_TRIGGER.sql
+++ b/src/main/resources/db/trigger/INSERT_ASSET_SPECIFIC_TRIGGER.sql
@@ -1,0 +1,7 @@
+create or replace TRIGGER insert_asset_specific_trigger
+AFTER INSERT ON CUSTOMER
+FOR EACH ROW
+BEGIN
+INSERT INTO asset (ASS_ID, C_ID) VALUES (ASSET_SEQ.nextval, :NEW.C_ID);
+INSERT INTO specific (C_ID, spc_rank, spc_creditrank) VALUES (:NEW.C_ID, '일반', 5);
+END;


### PR DESCRIPTION
### 코드 작성 이유
신규 손님 가입시에 Asset과 Specific 데이터가 없어서 프로필 화면이 안불러와지는 문제 발생 해결을 위함.
<br>

### 상세 사항
트리거 구문을 남겨놓기 위해 PR에 올립니다. 원격 DB에는 추가되어 있습니다.
<br>

### 참고 사항

<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
