### PR TITLE
Feat: 프로필 페이지 계좌번호 추가 , 중복되어서 나오던 항목 제거

### DIFF
--- a/src/main/java/hana/teamfour/addminhana/DTO/AccountDTO.java
+++ b/src/main/java/hana/teamfour/addminhana/DTO/AccountDTO.java
@@ -12,4 +12,5 @@ public class AccountDTO {
     private String acc_pname;
     private Double acc_interestrate;
     private String acc_maturitydate;
+    private Integer acc_id;
 }

--- a/src/main/java/hana/teamfour/addminhana/service/AccountService.java
+++ b/src/main/java/hana/teamfour/addminhana/service/AccountService.java
@@ -39,7 +39,8 @@ public class AccountService {
             Double acc_interestrate = accountEntity.getAcc_interestrate();
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
             String acc_maturitydate = dateFormat.format(accountEntity.getAcc_maturitydate());
-            accountDTO.add(new AccountDTO(acc_balance, acc_pname, acc_interestrate, acc_maturitydate));
+            Integer acc_id = accountEntity.getAcc_id();
+            accountDTO.add(new AccountDTO(acc_balance, acc_pname, acc_interestrate, acc_maturitydate, acc_id));
         }
 
         return accountDTO;

--- a/src/main/webapp/views/profile.jsp
+++ b/src/main/webapp/views/profile.jsp
@@ -161,6 +161,8 @@ Settings | File Templates. --%>
                       %>
                       <li>
                         <div class="productName"><%=account.getAcc_pname()%>
+                          <span class="fs-10"> [계좌번호 : <%=account.getAcc_id()%>]
+                          </span>
                         </div>
                         <span>만기일 <%=account.getAcc_maturitydate()%></span>
                         <span>이자율 <%=account.getAcc_interestrate()%>%</span>
@@ -184,6 +186,8 @@ Settings | File Templates. --%>
                       %>
                       <li>
                         <div class="productName"><%=account.getAcc_pname()%>
+                          <span class="fs-10"> [계좌번호 : <%=account.getAcc_id()%>]
+                          </span>
                         </div>
                         <span>만기일 <%=account.getAcc_maturitydate()%></span>
                         <span>이자율 <%=account.getAcc_interestrate()%>%</span>
@@ -207,6 +211,8 @@ Settings | File Templates. --%>
                       %>
                       <li>
                         <div class="productName"><%=account.getAcc_pname()%>
+                          <span class="fs-10"> [계좌번호 : <%=account.getAcc_id()%>]
+                          </span>
                         </div>
                         <span>만기일 <%=account.getAcc_maturitydate()%></span>
                         <span>이자율 <%=account.getAcc_interestrate()%>%</span>

--- a/src/main/webapp/views/profile.jsp
+++ b/src/main/webapp/views/profile.jsp
@@ -138,29 +138,6 @@ Settings | File Templates. --%>
                       %>
                       <li>
                         <div class="productName"><%=account.getAcc_pname()%>
-                        </div>
-                        <span>만기일 <%=account.getAcc_maturitydate()%></span>
-                        <span>이자율 <%=account.getAcc_interestrate()%>%</span>
-                        <span><%=balance%> <%=account.getAcc_balance()%>원</span>
-                      </li>
-                      <%
-                        }
-                      %>
-                    </ul>
-                  </c:if>
-                  <c:if test="${not empty savingsAccountList}">
-                    <p>
-                      <span style="font-size:1.25rem;margin-right: 2rem;">적금 상품</span>
-                      <span class="card-text">₩
-                          <fmt:formatNumber type="number" maxFractionDigits="3" value="${savings}"/>
-                        </span>
-                    </p>
-                    <ul class="signedupProductList">
-                      <%
-                        for (AccountDTO account : depositAccountList) {
-                      %>
-                      <li>
-                        <div class="productName"><%=account.getAcc_pname()%>
                           <span class="fs-10"> [계좌번호 : <%=account.getAcc_id()%>]
                           </span>
                         </div>


### PR DESCRIPTION
### 코드 작성 이유
프로필 페이지 계좌번호 추가 , 중복되어서 나오던 항목 제거
<br>

### 상세 사항
프로필 페이지의 account 들 옆에 이제 계좌번호가 나옵니다.
제목은 적금 상품 내용물은 예금상품이면서 다른것들과 중복되던 버그항목을 제거했습니다.
<br>

### 참고 사항

#### 수정 전
![image](https://github.com/Ansix1207/ERP/assets/112413977/38e1b8cf-c9bb-43ff-9cd7-cfe861952e46)

#### 수정 후
![image](https://github.com/Ansix1207/ERP/assets/112413977/f94e2ac7-61fd-4986-8cc2-1e3824f969c5)


<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
